### PR TITLE
LaTeX 수식(KaTeX) 지원 기능 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,7 @@ WENIV Presenter는 Marp의 대안으로 제작된 GitHub Pages 기반 마크다�
 - **Tailwind CSS**: 유틸리티 우선 CSS 프레임워크 (CDN)
 - **Marked.js**: 마크다운 파싱 (CDN)
 - **Prism.js**: 코드 문법 강조 (CDN)
+- **KaTeX**: LaTeX 수학 표현식 렌더링 (CDN)
 - **GitHub REST API**: 저장소 콘텐츠 접근용
 
 ## 개발 가이드라인
@@ -88,3 +89,6 @@ WENIV Presenter는 Marp의 대안으로 제작된 GitHub Pages 기반 마크다�
   - `{highlight}텍스트{/highlight}` - 하이라이트
   - `{bold}텍스트{/bold}` - 굵은 텍스트
   - `**텍스트**` - 자동 하이라이트 효과
+- **LaTeX 구문**:
+  - `$수식$` - 인라인 수학 표현식
+  - `$$수식$$` - 블록 수학 표현식

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ URL: https://weniv.github.io/mdpre/
 - **GitHub API 연동**: 리포지토리의 마크다운 파일을 자동으로 탐지하고 슬라이드로 변환
 - **실시간 프레젠테이션**: 부드러운 슬라이드 전환과 키보드 단축키 지원
 - **커스텀 텍스트 문법**: 텍스트 중앙정렬, 크기 조정, 강조 등 특별한 마크다운 문법 지원
+- **LaTeX 수학 표현식**: KaTeX를 사용한 수학 공식 렌더링 지원
 - **반응형 디자인**: 모바일, 태블릿, 데스크톱 모든 환경에서 최적화
 - **다중 테마**: 기본, 다크, 학술용 테마 지원
 - **향상된 전체화면 모드**: 완벽한 키보드 지원과 올바른 중앙 정렬
@@ -152,6 +153,73 @@ console.log("Hello, World!");<br>
 | `{highlight}텍스트{/highlight}` | 커스텀 하이라이트 | 🟢 강조된 텍스트 |
 | `{bold}텍스트{/bold}` | 커스텀 굵은 텍스트 | **굵은 텍스트** |
 
+### 🔢 LaTeX 수학 표현식
+
+프레젠테이션에서 LaTeX 문법을 사용하여 수학 표현식을 렌더링할 수 있습니다:
+
+#### 인라인 수학 표현식
+
+```markdown
+이것은 인라인 수학 표현식입니다: $E = mc^2$
+```
+
+#### 블록 수학 표현식
+
+```markdown
+이것은 블록 수학 표현식입니다:
+
+$$
+\int_{-\infty}^{\infty} e^{-x^2} dx = \sqrt{\pi}
+$$
+```
+
+#### 수학 표현식 예시
+
+```markdown
+---
+# 수학 공식 예제
+
+인라인 수학: $ax^2 + bx + c = 0$의 해는 다음과 같습니다:
+
+$$
+x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}
+$$
+
+분수와 극한:
+$$
+\lim_{n \to \infty} \frac{1}{n} = 0
+$$
+
+행렬:
+$$
+\begin{pmatrix}
+a & b \\
+c & d
+\end{pmatrix}
+$$
+
+---
+```
+
+#### 지원되는 LaTeX 문법
+
+- **기본 연산**: `+`, `-`, `*`, `/`, `=`
+- **분수**: `\frac{분자}{분모}`
+- **첨자**: `x^2`, `x_i`
+- **그리스 문자**: `\alpha`, `\beta`, `\gamma`, `\pi`, `\sigma` 등
+- **함수**: `\sin`, `\cos`, `\tan`, `\log`, `\ln`, `\exp` 등
+- **적분**: `\int`, `\sum`, `\prod`
+- **극한**: `\lim`, `\infty`
+- **행렬**: `\begin{matrix}...\end{matrix}`, `\begin{pmatrix}...\end{pmatrix}`
+- **루트**: `\sqrt{x}`, `\sqrt[n]{x}`
+- **기타**: `\pm`, `\mp`, `\cdot`, `\times`, `\div` 등
+
+#### 주의사항
+
+- 수학 표현식이 올바르게 렌더링되지 않는 경우 LaTeX 문법을 확인해주세요
+- 복잡한 수학 표현식은 블록 형태(`$$...$$`)로 사용하는 것을 권장합니다
+- PDF 내보내기 시에도 수학 표현식이 정상적으로 렌더링됩니다
+
 ### 🖼️ 로고 추가
 
 프레젠테이션에 로고를 추가하려면 다음 이름 중 하나로 이미지 파일을 업로드하세요:
@@ -221,6 +289,7 @@ console.log("Hello, World!");<br>
 - **프론트엔드**: Vanilla JavaScript + Tailwind CSS
 - **마크다운 파서**: Marked.js
 - **코드 하이라이팅**: Prism.js
+- **수학 표현식**: KaTeX
 - **API**: GitHub REST API
 - **배포**: GitHub Pages
 
@@ -316,5 +385,6 @@ github-markdown-presenter/
 
 - [Marked.js](https://marked.js.org/) - 마크다운 파싱
 - [Prism.js](https://prismjs.com/) - 코드 문법 강조
+- [KaTeX](https://katex.org/) - 수학 표현식 렌더링
 - [Tailwind CSS](https://tailwindcss.com/) - 유틸리티 CSS 프레임워크
 - [GitHub API](https://docs.github.com/en/rest) - 리포지토리 데이터 접근

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1078,6 +1078,50 @@ pre[class*=language-] {
         max-width: 120px !important;
         max-height: 120px !important;
     }
+
+    /* KaTeX math styling */
+    .math-display {
+        font-size: 1.1em !important;
+        margin: 1rem 0 !important;
+        text-align: center !important;
+        overflow-x: auto !important;
+    }
+
+    .math-inline {
+        font-size: 1em !important;
+        margin: 0 !important;
+        vertical-align: baseline !important;
+    }
+
+    .math-error {
+        color: #d32f2f !important;
+        background-color: #ffebee !important;
+        padding: 0.2rem 0.4rem !important;
+        border-radius: 0.25rem !important;
+        font-family: monospace !important;
+    }
+
+    /* PDF specific math styling */
+    .pdf-slide .math-display {
+        font-size: 1.2em !important;
+        margin: 1.5rem 0 !important;
+        text-align: center !important;
+        overflow-x: visible !important;
+    }
+
+    .pdf-slide .math-inline {
+        font-size: 1em !important;
+        margin: 0 !important;
+        vertical-align: baseline !important;
+    }
+
+    .pdf-slide .math-error {
+        color: #d32f2f !important;
+        background-color: #ffebee !important;
+        padding: 0.2rem 0.4rem !important;
+        border-radius: 0.25rem !important;
+        font-family: monospace !important;
+    }
     
     .pdf-logo-image {
         max-width: 120px !important;

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -21,6 +21,37 @@ class GitHubMarkdownPresenter {
         this.setupKeyboardNavigation();
         this.setupFullscreenHandling();
         this.getCurrentRepoInfo();
+        this.checkKatexLoaded();
+    }
+
+    checkKatexLoaded() {
+        // Check if KaTeX is loaded
+        const checkLoaded = () => {
+            if (typeof katex !== 'undefined') {
+                console.log('KaTeX library loaded successfully');
+                return true;
+            } else {
+                console.log('KaTeX library not yet loaded, waiting...');
+                return false;
+            }
+        };
+        
+        // Check immediately
+        if (!checkLoaded()) {
+            // If not loaded, check every 100ms for up to 5 seconds
+            let attempts = 0;
+            const maxAttempts = 50;
+            
+            const checkInterval = setInterval(() => {
+                attempts++;
+                if (checkLoaded() || attempts >= maxAttempts) {
+                    clearInterval(checkInterval);
+                    if (attempts >= maxAttempts) {
+                        console.error('KaTeX library failed to load after 5 seconds');
+                    }
+                }
+            }, 100);
+        }
     }
 
     bindEvents() {
@@ -1033,6 +1064,9 @@ class GitHubMarkdownPresenter {
             // Process images to use GitHub raw URLs
             let processedContent = this.processImageUrls(content.trim(), owner, repo, folderPath);
             
+            // Process LaTeX expressions before markdown parsing
+            processedContent = this.processLatexExpressions(processedContent);
+            
             // Configure marked with breaks option for line breaks
             const markedOptions = {
                 breaks: true,  // Enable line breaks
@@ -1193,6 +1227,7 @@ class GitHubMarkdownPresenter {
             }
             
             this.applySyntaxHighlighting();
+            this.renderMathExpressions(); // Render LaTeX expressions
             this.applySettings(); // Apply font settings after content update
             
             slideContent.style.opacity = '1';
@@ -1205,6 +1240,165 @@ class GitHubMarkdownPresenter {
         if (window.Prism) {
             Prism.highlightAll();
         }
+    }
+
+    processLatexExpressions(content) {
+        // Process LaTeX expressions in markdown content
+        // First, protect code blocks from LaTeX processing
+        const codeBlockRegex = /```[\s\S]*?```|`[^`]*`/g;
+        const codeBlocks = [];
+        let protectedContent = content.replace(codeBlockRegex, (match) => {
+            const placeholder = `__CODE_BLOCK_${codeBlocks.length}__`;
+            codeBlocks.push(match);
+            return placeholder;
+        });
+        
+        // Handle block math ($$...$$) - convert to KaTeX displaymath
+        protectedContent = protectedContent.replace(/\$\$([\s\S]*?)\$\$/g, (match, math) => {
+            // Escape math expression to prevent conflicts
+            const escapedMath = math.trim();
+            return `<div class="math-display" data-math="${this.escapeMath(escapedMath)}"></div>`;
+        });
+        
+        // Handle inline math ($...$) - convert to KaTeX inline
+        // Use a more compatible regex that avoids lookbehind assertions
+        protectedContent = protectedContent.replace(/\$([^$\n\r]+?)\$/g, (match, math) => {
+            // Avoid matching if it's already part of a code block or escaped
+            const escapedMath = math.trim();
+            return `<span class="math-inline" data-math="${this.escapeMath(escapedMath)}"></span>`;
+        });
+        
+        // Restore code blocks
+        protectedContent = protectedContent.replace(/__CODE_BLOCK_(\d+)__/g, (match, index) => {
+            return codeBlocks[parseInt(index)];
+        });
+        
+        return protectedContent;
+    }
+
+    escapeHtml(text) {
+        const map = {
+            '&': '&amp;',
+            '<': '&lt;',
+            '>': '&gt;',
+            '"': '&quot;',
+            "'": '&#039;'
+        };
+        return text.replace(/[&<>"']/g, (m) => map[m]);
+    }
+
+    unescapeHtml(text) {
+        const map = {
+            '&amp;': '&',
+            '&lt;': '<',
+            '&gt;': '>',
+            '&quot;': '"',
+            '&#039;': "'"
+        };
+        return text.replace(/&(amp|lt|gt|quot|#039);/g, (m) => map[m]);
+    }
+
+    escapeMath(text) {
+        // Preserve backslashes and other special characters for LaTeX
+        return text.replace(/\\/g, '\\\\').replace(/"/g, '&quot;').replace(/'/g, '&#039;');
+    }
+
+    unescapeMath(text) {
+        // Restore backslashes and other special characters for LaTeX
+        return text.replace(/\\\\/g, '\\').replace(/&quot;/g, '"').replace(/&#039;/g, "'");
+    }
+
+    renderMathExpressions() {
+        // Render LaTeX expressions using KaTeX
+        // Add a small delay to ensure DOM is updated and KaTeX is loaded
+        setTimeout(() => {
+            if (typeof katex !== 'undefined') {
+                const slideContent = document.getElementById('slide-content');
+                if (slideContent) {
+                    this.renderMathInElement(slideContent);
+                }
+            } else {
+                // If KaTeX is not loaded yet, try again after a longer delay
+                setTimeout(() => {
+                    if (typeof katex !== 'undefined') {
+                        const slideContent = document.getElementById('slide-content');
+                        if (slideContent) {
+                            this.renderMathInElement(slideContent);
+                        }
+                    } else {
+                        console.warn('KaTeX library not loaded. Math expressions will not be rendered.');
+                    }
+                }, 500);
+            }
+        }, 100);
+    }
+
+    renderMathForPDF(element) {
+        // Render LaTeX expressions for PDF export
+        // Use a synchronous approach for PDF rendering
+        if (typeof katex !== 'undefined') {
+            this.renderMathInElement(element);
+        } else {
+            // If KaTeX is not available, show the raw LaTeX
+            const mathElements = element.querySelectorAll('.math-display, .math-inline');
+            mathElements.forEach(el => {
+                const mathContent = this.unescapeMath(el.getAttribute('data-math'));
+                if (el.classList.contains('math-display')) {
+                    el.textContent = `$$${mathContent}$$`;
+                } else {
+                    el.textContent = `$${mathContent}$`;
+                }
+                el.classList.add('math-error');
+            });
+        }
+    }
+
+    renderMathInElement(container) {
+        // Process display math
+        const displayMathElements = container.querySelectorAll('.math-display');
+        console.log(`Found ${displayMathElements.length} display math elements`);
+        
+        displayMathElements.forEach((el, index) => {
+            const mathContent = this.unescapeMath(el.getAttribute('data-math'));
+            console.log(`Rendering display math ${index + 1}:`, mathContent);
+            
+            try {
+                katex.render(mathContent, el, {
+                    displayMode: true,
+                    throwOnError: false,
+                    trust: true
+                });
+                console.log(`Successfully rendered display math ${index + 1}`);
+            } catch (e) {
+                console.warn('KaTeX display math render error:', e);
+                console.log('Failed math content:', mathContent);
+                el.textContent = `$$${mathContent}$$`;
+                el.classList.add('math-error');
+            }
+        });
+
+        // Process inline math
+        const inlineMathElements = container.querySelectorAll('.math-inline');
+        console.log(`Found ${inlineMathElements.length} inline math elements`);
+        
+        inlineMathElements.forEach((el, index) => {
+            const mathContent = this.unescapeMath(el.getAttribute('data-math'));
+            console.log(`Rendering inline math ${index + 1}:`, mathContent);
+            
+            try {
+                katex.render(mathContent, el, {
+                    displayMode: false,
+                    throwOnError: false,
+                    trust: true
+                });
+                console.log(`Successfully rendered inline math ${index + 1}`);
+            } catch (e) {
+                console.warn('KaTeX inline math render error:', e);
+                console.log('Failed math content:', mathContent);
+                el.textContent = `$${mathContent}$`;
+                el.classList.add('math-error');
+            }
+        });
     }
 
     updateNavigation() {
@@ -1982,6 +2176,9 @@ class GitHubMarkdownPresenter {
             // For local files, keep relative paths as they are
             let processedContent = content.trim();
             
+            // Process LaTeX expressions before markdown parsing
+            processedContent = this.processLatexExpressions(processedContent);
+            
             // Configure marked with breaks option for line breaks
             const markedOptions = {
                 breaks: true,  // Enable line breaks
@@ -2486,6 +2683,9 @@ class GitHubMarkdownPresenter {
                     Prism.highlightElement(block);
                 });
             }
+            
+            // PDF용 LaTeX 수식 렌더링
+            this.renderMathForPDF(slideDiv);
             
             // HTML 삽입 후 폰트 설정 적용
             this.applyFontsToElement(slideDiv);

--- a/index.html
+++ b/index.html
@@ -45,6 +45,12 @@
     <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-core.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
+    
+    <!-- KaTeX for LaTeX math rendering -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/contrib/auto-render.min.js"></script>
+    
     <link href="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism.min.css" rel="stylesheet">
     <link href="./assets/css/style.css" rel="stylesheet">
 </head>


### PR DESCRIPTION
- 주요 변경 사항

    - KaTeX 로딩 체크 기능 추가

        - KaTeX 라이브러리의 로딩 여부를 확인하는 checkKatexLoaded() 메서드 추가

        - 라이브러리가 로드되지 않은 경우 최대 5초간(100ms 간격, 최대 50회) 재시도

    - 슬라이드 렌더링 시 수식 처리

        - 슬라이드 전환 시 renderMathExpressions()를 호출하여 LaTeX 수식 자동 렌더링

        - PDF 내보내기 시에도 수식 렌더링 지원(renderMathForPDF)

    - 마크다운 내 LaTeX 수식 파싱 및 보호

        - 코드 블록 및 인라인 코드 내 수식 파싱 방지

        - 블록 수식($$...$$)과 인라인 수식($...$)을 각각 KaTeX용 HTML로 변환

        - 수식 내 특수문자 이스케이프/복원 처리(escapeMath, unescapeMath)

    - 수식 렌더링 오류 처리

        - KaTeX 렌더링 실패 시 원본 LaTeX을 표시하고 오류 스타일(math-error) 적용

- 상세 구현 내역

    `processLatexExpressions(content)`
    마크다운 내에서 코드 블록을 보호한 뒤, 블록/인라인 수식을 KaTeX용 HTML로 변환

    `renderMathInElement(container)`
    .math-display, .math-inline 클래스를 가진 요소를 찾아 각각 KaTeX로 렌더링

    - renderMathExpressions() DOM 업데이트와 KaTeX 로딩을 보장하기 위해 딜레이 후 수식 렌더링 시도

    `renderMathForPDF(element)`
    PDF 내보내기 시에도 KaTeX 렌더링, 미로딩 시 원본 수식 표시